### PR TITLE
Add aiops-prod-argo manifests

### DIFF
--- a/argo-events/overlays/aiops-prod-argo/kustomization.yaml
+++ b/argo-events/overlays/aiops-prod-argo/kustomization.yaml
@@ -1,0 +1,29 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: aiops-prod-argo
+
+commonLabels:
+  app.kubernetes.io/name: argo-events
+  app.kubernetes.io/component: workflow-engine
+  app.kubernetes.io/part-of: aiops-analytics
+  app.kubernetes.io/managed-by: aicoe-aiops-devops-argocd
+
+resources:
+  - ../../base
+  - ./membership.yaml
+
+patchesJson6902:
+  - patch: &patch |
+      - op: replace
+        path: /data/config
+        value: |
+          namespace: aiops-prod-argo
+    target: &target
+      kind: ConfigMap
+      name: gateway-controller-configmap
+      version: v1
+  - patch: *patch
+    target:
+      <<: *target
+      name: sensor-controller-configmap

--- a/argo-events/overlays/aiops-prod-argo/membership.yaml
+++ b/argo-events/overlays/aiops-prod-argo/membership.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: project-argo-events-users
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argo-events-user
+subjects:
+  - kind: Group
+    name: data-hub-admins
+  - kind: Group
+    name: data-hub
+  - kind: Group
+    name: aicoe-aiops-devops

--- a/argo/overlays/aiops-prod-argo/kustomization.yaml
+++ b/argo/overlays/aiops-prod-argo/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: aiops-prod-argo
+
+commonLabels:
+  app.kubernetes.io/name: argo
+  app.kubernetes.io/component: workflow-engine
+  app.kubernetes.io/part-of: aiops-analytics
+  app.kubernetes.io/managed-by: aicoe-aiops-devops-argocd
+
+resources:
+  - ../../base
+  - ./membership.yaml

--- a/argo/overlays/aiops-prod-argo/membership.yaml
+++ b/argo/overlays/aiops-prod-argo/membership.yaml
@@ -1,0 +1,58 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: project-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - kind: Group
+    name: data-hub-admins
+  - kind: Group
+    name: aicoe-aiops-devops
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: project-viewers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: Group
+    name: data-hub
+  - kind: Group
+    name: aicoe-aiops
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: project-argo-users
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argo-user
+subjects:
+  - kind: Group
+    name: data-hub-admins
+  - kind: Group
+    name: data-hub
+  - kind: Group
+    name: aicoe-aiops-devops
+  - kind: Group
+    name: aicoe-aiops
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - kind: ServiceAccount
+    name: argocd-manager
+    namespace: aicoe-argocd


### PR DESCRIPTION
Successor of: https://github.com/AICoE/aicoe-sre/pull/40

Includes another Argo and Argo Events namespace - "aiops-prod-argo" on the "ocp.psi.redhat.com" cluster.