### PR TITLE
Update argo to 2.11.1

### DIFF
--- a/argo/base/argo-user-role.yaml
+++ b/argo/base/argo-user-role.yaml
@@ -6,8 +6,11 @@ rules:
   - apiGroups:
       - argoproj.io
     resources:
+      - cronworkflows
+      - cronworkflows/finalizers
       - workflows
       - workflows/finalizers
+      - workfloweventbindings
       - workflowtemplates
       - workflowtemplates/finalizers
     verbs:

--- a/argo/base/kustomization.yaml
+++ b/argo/base/kustomization.yaml
@@ -7,8 +7,8 @@ resources:
   - ./default-sa-rolebinding.yaml
   - ./argo-server-route.yaml
   - ./workflow-controller-metrics-route.yaml
-  - github.com/argoproj/argo/manifests/namespace-install?ref=v2.8.2
-  - https://raw.githubusercontent.com/argoproj/argo/v2.8.2/manifests/cluster-install/workflow-controller-rbac/workflow-aggregate-roles.yaml
+  - github.com/argoproj/argo/manifests/namespace-install?ref=v2.11.0
+  - https://raw.githubusercontent.com/argoproj/argo/v2.11.0/manifests/cluster-install/workflow-controller-rbac/workflow-aggregate-roles.yaml
 
 patchesStrategicMerge:
   - ./workflow-controller-configmap.yaml

--- a/argo/base/kustomization.yaml
+++ b/argo/base/kustomization.yaml
@@ -7,8 +7,8 @@ resources:
   - ./default-sa-rolebinding.yaml
   - ./argo-server-route.yaml
   - ./workflow-controller-metrics-route.yaml
-  - github.com/argoproj/argo/manifests/namespace-install?ref=v2.11.0
-  - https://raw.githubusercontent.com/argoproj/argo/v2.11.0/manifests/cluster-install/workflow-controller-rbac/workflow-aggregate-roles.yaml
+  - github.com/argoproj/argo/manifests/namespace-install?ref=v2.11.1
+  - https://raw.githubusercontent.com/argoproj/argo/v2.11.1/manifests/cluster-install/workflow-controller-rbac/workflow-aggregate-roles.yaml
 
 patchesStrategicMerge:
   - ./workflow-controller-configmap.yaml

--- a/argo/base/workflow-controller-configmap.yaml
+++ b/argo/base/workflow-controller-configmap.yaml
@@ -4,7 +4,3 @@ metadata:
   name: workflow-controller-configmap
 data:
   containerRuntimeExecutor: k8sapi
-  metricsConfig: |
-    enabled: true
-    path: /metrics
-    port: 9090


### PR DESCRIPTION
Upgrades to Argo 2.11.1. This is a huge upgrade, the difference between 2.8.2 and 2.11.1 is night and day - much more polished product allowing simpler workflow definitions + more control over it. :slightly_smiling_face: 

Requires a new CRD on affected clusters - `WorkflowEventBinding` since Argo can now listen for events and webhooks (means there may be no need Argo Events anymore).

Only thing that's not working as expected, is submitting `CronWorkflow`s from UI, which is a permission issue - solved in upstream https://github.com/argoproj/argo/pull/4112 

^ just a minor inconvenience, will be probably fixed in later revision/patch release, there's no need to diverge from upstream just to apply a workaround for a barely used feature.

Metric exposing is fixed now, there's no need to hardcode it in the configmap.
