### PR TITLE
Default workflow settings for aiops-prod-argo

### DIFF
--- a/argo/overlays/aiops-prod-argo/kustomization.yaml
+++ b/argo/overlays/aiops-prod-argo/kustomization.yaml
@@ -12,3 +12,6 @@ commonLabels:
 resources:
   - ../../base
   - ./membership.yaml
+
+patchesStrategicMerge:
+  - ./workflow-controller-configmap.yaml

--- a/argo/overlays/aiops-prod-argo/workflow-controller-configmap.yaml
+++ b/argo/overlays/aiops-prod-argo/workflow-controller-configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: workflow-controller-configmap
+data:
+  workflowDefaults: |
+    spec:
+      # must complete in 8h (28,800 seconds)
+      activeDeadlineSeconds: 28800
+
+      # keep workflows for 24h (86,400 seconds). If workflow succeeded keep for 1h (3,600 seconds) only
+      ttlStrategy:
+        secondsAfterCompletion: 86400
+        secondsAfterSuccess: 3600


### PR DESCRIPTION
Let's enforce a TTL on `aiops-prod-argo`. Default values will be:

- 8 hours to finish
- 24 hours to keep them in the cluster at most in all cases
- 1 hour if finished successfully

These values can be changed on per-workflow definitions, these are just new defaults.

Ref: https://argoproj.github.io/argo/default-workflow-specs/#setting-default-workflow-values