### PR TITLE
Add custom profile for shanand user and reorder custom profiles

### DIFF
--- a/jupyterhub/bases/custom-profiles/jupyterhub-singleuser-profiles.yaml
+++ b/jupyterhub/bases/custom-profiles/jupyterhub-singleuser-profiles.yaml
@@ -10,38 +10,35 @@ profiles:
       operator: Equal
       value: gpu-baremetal
       effect: NoSchedule
-- name: Don profile
-  users:
-    - dcheswor
-    - weaton
-  resources:
-    mem_limit: 256Gi
-    cpu_limit: 16
-- name: AI Ops Users
-  users:
-    - mcliffor
-    - kachauha
-    - ochatter
-    - hveeradh
-    - shanand
-    - aduggal
-    - sbadhe
-    - rtripath
-    - supathak
-  resources:
-    mem_limit: 32Gi
-    cpu_limit: 4
-- name: Users with 16 GB RAM
-  users:
-    - esammons
-    - cdolfi
-  resources:
-    mem_limit: 16Gi
-- name: Users with 32 GB
-  users:
-    - dmulford
-  resources:
-    mem_limit: 32Gi
+- name: Spark Notebook
+  images:
+  - 's2i-spark-minimal-notebook:3.6'
+  - 's2i-spark-scipy-notebook:3.6'
+  - 's2i-spark-minimal-notebook-with-libsndfile:3.6'
+  - 's2i-spark-scipy-notebook-with-libsndfile:3.6'
+  env:
+    PYSPARK_SUBMIT_ARGS: '--packages com.amazonaws:aws-java-sdk:1.7.4,org.apache.hadoop:hadoop-aws:2.7.3 pyspark-shell'
+    PYSPARK_DRIVER_PYTHON: "jupyter"
+    PYSPARK_DRIVER_PYTHON_OPTS: "notebook"
+    SPARK_HOME: '/opt/app-root/lib/python3.6/site-packages/pyspark/'
+    PYTHONPATH: '$PYTHONPATH:/opt/app-root/lib/python3.6/site-packages/:/opt/app-root/lib/python3.6/site-packages/pyspark/python/:/opt/app-root/lib/python3.6/site-packages/pyspark/python/lib/py4j-0.8.2.1-src.zip'
+  services:
+    spark:
+      template: jupyterhub-spark-operator-configmap
+      configuration:
+        WORKER_NODES: '2'
+        MASTER_NODES: '1'
+        MASTER_MEMORY_LIMIT: '2Gi'
+        MASTER_CPU_LIMIT: '1'
+        MASTER_MEMORY_REQUEST: '2Gi'
+        MASTER_CPU_REQUEST: '1'
+        WORKER_MEMORY_LIMIT: '2Gi'
+        WORKER_CPU_LIMIT: '1'
+        WORKER_MEMORY_REQUEST: '2Gi'
+        WORKER_CPU_REQUEST: '1'
+        SPARK_IMAGE: 'quay.io/radanalyticsio/openshift-spark-py36:2.4.5-2'
+      return:
+        SPARK_CLUSTER: 'metadata.name'
 - name: Spark 2.4 Notebook
   images:
     - 's2i-spark24-minimal-notebook:3.6'
@@ -72,36 +69,60 @@ profiles:
         SPARK_IMAGE: quay.io/radanalyticsio/openshift-spark:2.4-latest
       return:
         SPARK_CLUSTER: 'metadata.name'
-- name: Spark Notebook
-  images:
-  - 's2i-spark-minimal-notebook:3.6'
-  - 's2i-spark-scipy-notebook:3.6'
-  - 's2i-spark-minimal-notebook-with-libsndfile:3.6'
-  - 's2i-spark-scipy-notebook-with-libsndfile:3.6'
-  env:
-    PYSPARK_SUBMIT_ARGS: '--packages com.amazonaws:aws-java-sdk:1.7.4,org.apache.hadoop:hadoop-aws:2.7.3 pyspark-shell'
-    PYSPARK_DRIVER_PYTHON: "jupyter"
-    PYSPARK_DRIVER_PYTHON_OPTS: "notebook"
-    SPARK_HOME: '/opt/app-root/lib/python3.6/site-packages/pyspark/'
-    PYTHONPATH: '$PYTHONPATH:/opt/app-root/lib/python3.6/site-packages/:/opt/app-root/lib/python3.6/site-packages/pyspark/python/:/opt/app-root/lib/python3.6/site-packages/pyspark/python/lib/py4j-0.8.2.1-src.zip'
+- name: Don profile
+  users:
+    - dcheswor
+    - weaton
+  resources:
+    mem_limit: 256Gi
+    cpu_limit: 16
+- name: AI Ops Users
+  users:
+    - mcliffor
+    - kachauha
+    - ochatter
+    - hveeradh
+    - aduggal
+    - sbadhe
+    - rtripath
+    - supathak
+  resources:
+    mem_limit: 32Gi
+    cpu_limit: 4
+- name: Special request for user shanand to handle insights data
+  users:
+    - shanand
+  resources:
+    mem_limit: 32Gi
+    cpu_limit: 4
   services:
     spark:
       template: jupyterhub-spark-operator-configmap
-      configuration:
-        WORKER_NODES: '2'
+      parameters:
+        WORKER_NODES: '4'
         MASTER_NODES: '1'
         MASTER_MEMORY_LIMIT: '2Gi'
         MASTER_CPU_LIMIT: '1'
         MASTER_MEMORY_REQUEST: '2Gi'
         MASTER_CPU_REQUEST: '1'
-        WORKER_MEMORY_LIMIT: '2Gi'
-        WORKER_CPU_LIMIT: '1'
-        WORKER_MEMORY_REQUEST: '2Gi'
-        WORKER_CPU_REQUEST: '1'
-        SPARK_IMAGE: 'quay.io/radanalyticsio/openshift-spark-py36:2.4.5-2'
+        WORKER_MEMORY_LIMIT: '4Gi'
+        WORKER_CPU_LIMIT: '4'
+        WORKER_MEMORY_REQUEST: '4Gi'
+        WORKER_CPU_REQUEST: '4'
+        SPARK_IMAGE: quay.io/radanalyticsio/openshift-spark-py36:2.4-latest
       return:
         SPARK_CLUSTER: 'metadata.name'
-
+- name: Users with 16 GB RAM
+  users:
+    - esammons
+    - cdolfi
+  resources:
+    mem_limit: 16Gi
+- name: Users with 32 GB
+  users:
+    - dmulford
+  resources:
+    mem_limit: 32Gi
 sizes:
   - name: Small
     resources:


### PR DESCRIPTION
This change was necessary based on some experiments that profiles are matched sequencially.

That way, if you have a custom user profile that changes spark cluster configuration, the latter image profiles that does the same changes will be applied.

The order that must be followed should be: global profile -> image-specific profiles -> user-specific profiles