### PR TITLE
include s2i-pytorch-notebook image to idh imagestreams

### DIFF
--- a/jupyterhub/bases/custom-images/jupyterhub-custom-images.yaml
+++ b/jupyterhub/bases/custom-images/jupyterhub-custom-images.yaml
@@ -338,3 +338,22 @@ spec:
     importPolicy:
       scheduled: true
     name: "latest"
+
+# s2i-pytorch-notebook
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true"
+  name: s2i-pytorch-notebook
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - from:
+      kind: DockerImage
+      name: quay.io/thoth-station/s2i-pytorch-notebook:v0.0.1
+    importPolicy:
+      scheduled: true
+    name: "latest"


### PR DESCRIPTION
include s2i-pytorch-notebook image to idh imagestreams
https://quay.io/repository/thoth-station/s2i-pytorch-notebook?tab=tags
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>