### PR TITLE
Fix DeploymentConfig api group in patches and commonlabels propagation

### DIFF
--- a/data-catalog/base/hue/kustomization.yaml
+++ b/data-catalog/base/hue/kustomization.yaml
@@ -35,4 +35,10 @@ patchesJson6902:
     target:
       kind: DeploymentConfig
       name: hue-mysql
+      group: apps.openshift.io
       version: v1
+
+commonLabels:
+  opendatahub.io/component: "true"
+  component.opendatahub.io/name: hue
+  component.opendatahub.io/part-of: data-catalog

--- a/data-catalog/base/kustomization.yaml
+++ b/data-catalog/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ./thriftserver
   - ./hue
-
-commonLabels:
-  opendatahub.io/component: "true"
-  component.opendatahub.io/name: data-catalog

--- a/data-catalog/base/thriftserver/kustomization.yaml
+++ b/data-catalog/base/thriftserver/kustomization.yaml
@@ -39,4 +39,10 @@ patchesJson6902:
     target:
       kind: DeploymentConfig
       name: thriftserver-postgres
+      group: apps.openshift.io
       version: v1
+
+commonLabels:
+  opendatahub.io/component: "true"
+  component.opendatahub.io/name: thriftserver
+  component.opendatahub.io/part-of: data-catalog

--- a/data-catalog/overlays/prod/hue/hue-dc.yaml
+++ b/data-catalog/overlays/prod/hue/hue-dc.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   name: hue


### PR DESCRIPTION
Since the apiVersion for `DeploymentConfig`s changed in #39 we need to adjust for the api group name in our patches.

- Add DC target's `group` in `patchesJson6902` in kustomization
- Change `apiVersion` in `patchesStrategicMerge` patch for `hue` DC

Also fix the `commonLabels` propagation from base. Since we are overlaying each component (thriftserver and hue) separately, we never include the `datacatalog/base/kustomization.yaml` so these labels are never applies. Moving them into each components fixes it  