### PR TITLE
Update endpoint for the thriftserver liveness probe

### DIFF
--- a/data-catalog/base/thriftserver/thriftserver-dc.yaml
+++ b/data-catalog/base/thriftserver/thriftserver-dc.yaml
@@ -63,7 +63,7 @@ spec:
           livenessProbe:
             failureThreshold: 4
             httpGet:
-              path: /
+              path: /jobs/
               port: 4040
               scheme: HTTP
             periodSeconds: 30


### PR DESCRIPTION
Previously, the Thriftserver liveness probe was configured to check the
/ endpoint of port 4040. This endpoint doesn't properly exercise any
behavior on the pod. With this change, we'll check the /jobs/ endpoint
(the trailing / is important). This is the same endpoint you hit when
you go to the Thriftserver WebUI. This change should result in OpenShift
automatically restarting the thriftserver when the UI becomes
unresponsive and substantially cut down on our alerts.