### PR TITLE
Downgrade argo 2.11.1 -> 2.11.0

### DIFF
--- a/argo/base/kustomization.yaml
+++ b/argo/base/kustomization.yaml
@@ -10,5 +10,24 @@ resources:
   - github.com/argoproj/argo/manifests/namespace-install?ref=v2.11.1
   - https://raw.githubusercontent.com/argoproj/argo/v2.11.1/manifests/cluster-install/workflow-controller-rbac/workflow-aggregate-roles.yaml
 
+images:
+  - name: argoproj/argocli
+    newName: quay.io/thoth-station/argocli
+    newTag: v2.11.0 # Does not match manifests!
+  - name: argoproj/workflow-controller
+    newName: quay.io/thoth-station/workflow-controller
+    newTag: v2.11.0 # Does not match manifests!
+
+patchesJson6902:
+  - patch: |
+      - op: replace
+        path: /spec/template/spec/containers/0/args/3
+        value: quay.io/thoth-station/argoexec:v2.11.0
+    target:
+      group: apps
+      kind: Deployment
+      name: workflow-controller
+      version: v1
+
 patchesStrategicMerge:
   - ./workflow-controller-configmap.yaml


### PR DESCRIPTION
Downgrade Argo images from 2.11.1 to 2.11.0 so we can use Thoth image repository instead of Docker Hub (and we don't need to bother them to push the images or duplicate the repositories), while keeping the manifests locked to 2.11.1. Reasoning:

- 2.11.1 manifests only changeset to 2.11.0 is a role fix for cron workflows, which we don't want to skip https://github.com/argoproj/argo/pull/4112 
- 2.11.0 images are available on quay in Thoth team repos and it would be rude to ask them to release for us either:
    1. 2.11.1 images which are already dated
    2. current latest 2.11.8 when 2.12 is in it's RC4 stage right now
    3. or create and additional repository just for ourselves, seems unnecessary

Let's rather downgrade to 2.11.0 images for now, wait until 2.12.0 and then work together with thoth team to get the 2.12 images into quay + upgrade all together to 2.12.0