### PR TITLE
Update custom image for ocp4-anomaly-detection

### DIFF
--- a/jupyterhub/bases/custom-images/jupyterhub-custom-images.yaml
+++ b/jupyterhub/bases/custom-images/jupyterhub-custom-images.yaml
@@ -190,7 +190,7 @@ spec:
       scheduled: true
     name: "latest"
 
-## OCP4 Anomaly Detection Image from https://gitlab.cee.redhat.com/AICoE/ocp4
+## OCP4 Anomaly Detection Image from https://github.com/aicoe-aiops/ocp4-anomaly-detection-internal
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
@@ -202,7 +202,7 @@ spec:
   tags:
   - from:
       kind: DockerImage
-      name: docker-registry.upshift.redhat.com/aicoe-notebooks/ocp4-anomaly-detection:latest
+      name: docker-registry.upshift.redhat.com/aicoe-notebooks/ocp4-anomaly-detection-internal:latest
     importPolicy:
       scheduled: true
     name: "latest"


### PR DESCRIPTION
We renamed the private repo for ocp4-anomaly-detection and created its public facing counterpart as per the guideline [here](https://github.com/aicoe-aiops/ai-enablement-initiative/blob/master/docs/create-consumable-artifacts.adoc#6-create-public-repository).

As a result, the image name also got updated. This PR addresses that name change.