### PR TITLE
feat: Upgrade Argo to v2.12.3

### DIFF
--- a/argo/base/kustomization.yaml
+++ b/argo/base/kustomization.yaml
@@ -7,22 +7,22 @@ resources:
   - ./default-sa-rolebinding.yaml
   - ./argo-server-route.yaml
   - ./workflow-controller-metrics-route.yaml
-  - github.com/argoproj/argo/manifests/namespace-install?ref=v2.11.1
-  - https://raw.githubusercontent.com/argoproj/argo/v2.11.1/manifests/cluster-install/workflow-controller-rbac/workflow-aggregate-roles.yaml
+  - github.com/argoproj/argo/manifests/namespace-install?ref=v2.12.3
+  - https://raw.githubusercontent.com/argoproj/argo/v2.12.3/manifests/cluster-install/workflow-controller-rbac/workflow-aggregate-roles.yaml
 
 images:
   - name: argoproj/argocli
-    newName: quay.io/thoth-station/argocli
-    newTag: v2.11.0 # Does not match manifests!
+    newName: quay.io/opendatahub/argocli
+    newTag: v2.12.3
   - name: argoproj/workflow-controller
-    newName: quay.io/thoth-station/workflow-controller
-    newTag: v2.11.0 # Does not match manifests!
+    newName: quay.io/opendatahub/workflow-controller
+    newTag: v2.12.3
 
 patchesJson6902:
   - patch: |
       - op: replace
         path: /spec/template/spec/containers/0/args/3
-        value: quay.io/thoth-station/argoexec:v2.11.0
+        value: quay.io/opendatahub/argoexec:v2.12.3
     target:
       group: apps
       kind: Deployment


### PR DESCRIPTION
Bumps the Argo version to `v2.12.3`. 

~~:warning: Requires the `quay.io/opendatahub/*` images to be available first (this should happen as part of https://github.com/opendatahub-io/odh-manifests/pull/208 ).~~

Images are available now: https://github.com/opendatahub-io/odh-manifests/pull/208#issuecomment-757967358 :tada: :100: 
