### PR TITLE
Use external hostname for spark in thriftserver instances

### DIFF
--- a/data-catalog/overlays/prod-ccx/thriftserver/thriftserver-server-conf-secret.enc.yaml
+++ b/data-catalog/overlays/prod-ccx/thriftserver/thriftserver-server-conf-secret.enc.yaml
@@ -5,28 +5,28 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 stringData:
-    thrift-server.conf: ENC[AES256_GCM,data:Zc5hmNsmrNjODKajcQCyEDu/K0jCj2OeQQiRc45semNArKrzAU476a0WB9WilihsO2dzeJj5YRKPIxwz05sRoiGFbyZzrORaVroR3oqBFI5wOnj6GbTR1SahXRRxvr37Rq2lREg0+w8SyrvsZ4b4Of2peMFGN5VaQehy3/r1jNTaQsCHPMMNopL4QjNCnyXaeDd0CpgXfpkxsi0k8EO+riQ1PM1JoZPndtB+lQdoLc6Gh1mUhnXCjxTYNWyEzoCHvnDlFKt9cQxrARtHkK39Cq1QHke/4IlDH5R9L3B+/6nqnvDA/CQwIuEesqI0ih2jgw9PoDgK8yW4JExi+1pupKXMNhxObeMZHND1o5z0ALKZoSHexdgLP7W/GinznNEogRjCktYXRREoRWFlQYkYwk/1l+FhlmSz9vGIFLlyTtvtniFZsxJlvAcHrnWGdyBbUWdHk4O6Tnv+IsLCTdSTkjujmXrxAGK2tFzSZ+hLUyXrM9+hwIGsBWdUmc06/GzAmRYi1HCOpn276USoymrblGyG33+FyI92KxBbx7xw/yNV6oRDb4qM4ExyaU1AjlzIWvwHVzYJmoPhxe0WkSYJJKiTT9XZU0mmsIk8gDN5LJMKPxk4EoAmEA8lRrT9YEp9vcg/JTnSr/RL1lWuJbBpYWQybK0WZyQxtCRTmVr1XRAwOrwgj/fesDtlOpKaTdda98Z5743vcX0aWmkRHQKgLHp6eHfswWLcZGZi7NmBMfi+Tc0CCkMAS4bv3kbz7eMKiRMJjIszx4lf9f/15DigjGFkM6y/+wLDwlX3eBE6ujeeDJMQUFJRcS2dE7WgyIhKHSHjXKJyA6euA0ZMqhYho072RIw7nDv6Pg0PxmTsChJnyp6bGcSwcrPl18/QnOqzsBK5JqrfWH5oRuGiHFgeUS36GEbBwXRVRX6LiJhSiVurYipS5la7mWZt9C0WAV73yWQKcR0ZDfG47vGzDV5AOVu5cUdhEJhBY8Xk3eTdQTzMKAojlCvHElTN5NULotjkSXXD78QV61lC7tpsPtaqbzKo7EfR3iiJPRgQ/8WpXydfXj5hZQM7IjPUgkFYXc13HNHinAv43b4LJ0v7rEF3kAhBFR+wSMCpzwIgDfCZcXkW8jis6KdrsJloj5WGp0ODNjBl2mocTV/SHeIhVTPH9hLoHtjNIijVOXwD7Cjj4DmvIclZFaBrFTVML9UpcU4Wi02GOeVC/S8ynmkN3TuCgVW1s7hblt9hkwocQZaQ0wS0U8hMgHGLwOGorMhkYFcZvCPSh4YOsPbsZw==,iv:UjLStwlHXZOkbAiluHeIACTyJeJMmpOc/mANnXw4M3Y=,tag:QEcnfFI+YZyHqss/7Hp4JA==,type:str]
+    thrift-server.conf: ENC[AES256_GCM,data:BF3g5f4G0D3uBDYwdH4FaZu2eAxxqlGE7nT4B2vEI8NyA9Zz/lTaRm0cq8A7iEY3is/b1Hvjdjlvn1Qvm4qQE58LvkeOHino79+g0U/nGWpngACIxOi3zwhSoBfTDH7T3QSlPlaDrJOW7gPh3Vm0qu2y2Zns7ZSrC7PiaCfSVxOvEZW+jAD+sv0k7ICMWBrAPWKhKtOhwRofwoihLu34AVi6StoE4T3jFF/mr7H2wLnpcwBQf7CDbmHNqPcFXTAbw+BBsIuLzA0eA/SjLNVaOnCUHmxNiougYJ7eZLz792/zWCwqHAxI7b3lRnOuD/fyiNLS/MyDOnpGznfk/5FTsTAlXPx6MRO0Ncicn4H0oj5f3EUArVRjIlC9kPBSfOTgpvQUkp0+956jnCMEZSLXv6XFVcnHtcVCkLlQkPi3/pzJTyYOhHMqN2WAfYQ9H02TpcnCSHuZAePG5DibzQZ1LodLh4WtcNkfJYGKtWvfMYrOYwBX/V85GEWwO6kQ9mi9WgtWlRLz+HhrnKtDoGQ2SbvoXzDV4RTmGYPhqvMZX/J9muQTUekL8rAbkoxGDM2ntnxfRPEZLXaYieUQ9wswyAE6FR2idOwXniyjHlPYJoDS1txyF3GeTFd5Yh4QiNuEOV6fHIN7Xl82Cwwf+JHF51Ol6Z+Sxt+06npPth0dAu722iz2WEUITgLAFqmtnDZZVs5ax03U/NvXPGH0xdtAgyiOiimZZ8DzJCcfGHrnKIaqSQ5vL2AI1iE3Hr6yIXfKdmExqDYCec88kXrOUa4n4VcPzjsTT1tHMbRGVWEP+UVOvknImxzlEqcywAKbHSohO/jQ5lPIcbRMw+pD2xvbcvrTUIkzwbeRcUULEm1y4Vx51We2DAwuaMiAW0sFptdQkcg3T8mfU3DBa+B4m8aZTmjKY175QNsrFQ4IQVumTvgXT2XRpG2rYRi3TdU7iur29pdQftlR4Xg7SuMiLKT24V/yXIb091F13swXZUx/1TLYG7SsgPN3GgnBqIK/lSy8SR+RGhX9pXQsA162V3axwpNdbJva3y6OmfSrBgHagU4VQEN5dGSvfAr7HfPFrH/IsV1zCxEJrL3RnanWuQgzNW+oMuBrIfRIPutlCmeqgprEBBYw/9kdzpmYI9dq5iIVjtfJnng/8XLn/nsdAib0goW/juuUHssuP1BRyRea3Qq5+bdhCLk9D0Ac4ekpRBXyxk8p31cPGmnw65FgUiECrdZvxc7I0uY=,iv:IY7dFp5VsC64vnOHZQX6MzZJOT8/GpmU9k/WiPf1AtA=,tag:94wndBuxRtdmHhU87uk3Kw==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2020-12-17T15:00:55Z'
-    mac: ENC[AES256_GCM,data:mKkBQXhqkNbgek/VheQmd2xSkfvlWLb0+O6zp5n9dodi57CXqvWA8hpyWjPPq/+CzjAqh7pjtegIh7jyyyvqQmUJEb2sUgAGq3Bphad+WPScmZ9PbVnoCAsWcM9jTfbKySl321eoyAUmXoCh6OyZHiVIcVYBtFS8HUYkdj5QHes=,iv:GIFiTkD9bF1hIOd6lEUEyFGW6sl57pxMIWKsBV2L5Ro=,tag:B+frmmNftYrgvOmgjdN/4Q==,type:str]
+    lastmodified: '2020-12-22T13:32:48Z'
+    mac: ENC[AES256_GCM,data:/8AWp07Mih5SO0JYFu32Jv6AZz6voqO73DzZ3C56MfaNEPbtY51KZZFzIQvM6zOnyF+aURh/CMG4CWcC+Ws+BAYh98qU1d0vcZsRK3JtlnpynwE4jF+3e7/VyYZzJvBF2nJ69VcgLgVfjOLN9mzWIWNf54M4WCoNe1ozY4xzDo8=,iv:xkDzAJ92MdfINeW6DjXapsHxPlYo7lzbaRKt+vr7JA0=,tag:Qi9+bowdrZSU6Sh0u498Dw==,type:str]
     pgp:
-    -   created_at: '2020-12-17T15:00:49Z'
+    -   created_at: '2020-12-22T13:32:48Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQEMA/irrHa183bxAQf/W/eVhREM39cKbTy6sY9xVo50bTta11nWSupeVhLfx19I
-            6YJyGG+dfFugGYJ01U2daHiSIOHP8PvdEnPp70esnMdFedOq1kUe3UvEQ4Djt+SJ
-            A453U6DbzbbhScxI+LlAF3VEpbFfAb4fQ5Lz45vi0jHTv42pLVaWvYT8lmZ5z5E/
-            Cx0bZCFSvBI0yyiqbqQiGjhcWOO3Z/xiyURz+XqLh/aJutsaRXyKnRh54dc6hdv1
-            rEiNAWajJ3jzsfusPOArx5DixYEP7NW0TPDbCtu5BuD104wBh3Y+svgRqcCwgVMU
-            98Eyi62rqXni9V1CCOfeFoSnaHx+DQxvWrpXsohHGdJeASxPF1HjY9KFXHH0SclD
-            AkLRV5KpyUxaVNt/1t56y3BAyhIpTRJ+DTIv5sgXPy9jJ/qQjG5kR8n1ltEn/w0Z
-            kBY4eJJxSZM8UN7eZ3dpKiPm2/htbWdhLIrGJWZlsQ==
-            =9ogJ
+            hQEMA/irrHa183bxAQf9H8kmNd7UXIeccjw2dPhB4CkgA4Mfc8KmMTuATJ8e2zTb
+            j7Asdxawcf7wv4ETX20d/oNurYViT0ijA4U4rWkZwN4LOwkJaTP/O3lym+bgPtqZ
+            bXCmlX8yNVPSVwBo5ggsoNtOMKArqpV9WLbpym/w+uZH1Ca+xVqJoyOdoCQ9nc5q
+            BlS1zLJMgI77Ptth+98VihokX51NhGTCD/WNCYA0SKEwsdUKs4txVk1vsLt+MGvX
+            CBLSswi265R2bEuwnU2/59w5OCk2c0mMDXqOVUd09f5MwSdnpyIfm/ZPJx+8JgrQ
+            z7eQ+PZz1yaQaeZ2KehCtejkxRrb/q0dRx5x3zkZtNJeAdpRxaqntL5OOfQr0Jkg
+            Y8JLpl49cYqDylcQyKEEVJ/Jqd5mxJT0OUgsFUAwmUa/VfS7cGzlTI1C1L/4eOTW
+            9A9eyTFsZcrHwgFCzlRbgEUdXCY1T7E+eovpZzCw2A==
+            =fK0d
             -----END PGP MESSAGE-----
         fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
     encrypted_regex: ^(data|stringData|tls)$

--- a/data-catalog/overlays/prod-usir/thriftserver/thriftserver-server-conf-secret.enc.yaml
+++ b/data-catalog/overlays/prod-usir/thriftserver/thriftserver-server-conf-secret.enc.yaml
@@ -5,28 +5,28 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 stringData:
-    thrift-server.conf: ENC[AES256_GCM,data:n6TuAqc4Cml0SQ7uHSiInG4caSi0UMj/ECf2Yldi8Pdoyq265RZYEGKziPp/NGPeyyKvyTbQbB5f1naOUA6W2xRO17KvUVcbvYtDNBWEGdM2W3K9w/R84ImwscbLltF6Jnl9W74r6wDj7IkCmQc2gJ7T4+LGYqXqvI/TmKhUpXHHWDB8YiA8EKjfagACYYfU+nzNM4df18JG/hEHcZrr/Ow5QArKhsEhJw/9b07OL37hn6IfD/wZG+zj3l9XNI4IBe8v4goHo0FaSdKgqdQKhECRuvk3Kl7oV9q1G7jweD7wtMUrN/bzViFqFwFPtUxceYRPle6Z1GZiJxFZxliaKtLrk6bWVSSENuI9G4IWuh3pcAJgDGn3uqGyAdTyxm5zwvA5Lu222JFbcmr+YDe3BEajl1OlPzHgHPItmtgECufKCvvomrlWrQtQVHMoocdgzT3/j/Lz2l81DKM7EcOkqe6mymlZe7Mff3EGWCQz6KxhWMZQDGxE8QDee3OL6jncxQseLpE9jhSLexubnuaUrrk5UhKMZy1MiKLb0lZ9YXybICdrl8G1ILlsSWOEb16ACVJtWKTwu1ejZSebH0/3TmTPr0YYhbJ6FyXn/n2IT2+YfC9Y81hRnlIfWnb76zOILkX60jOCTJ2Ih+C97ZO7FwougpxuxGq3SbisUS05Hg0ANYSr15hln0Z7GVMpRJaNvwkW/QLnPGAxmC309JGarxdiO18USsrNp2Ls2nHTyei4XCSMTAISdL1TBxRRXrzmo+Kl6EWdK5+HIWzZrI7Z/UB5YJkEChiRXq3zK7wmR7cD67CC3pHmQ2FjoZi46WIqVwVESeQtgKJ/K2ECvz7KoenIibFI5+mXGcjzW1jHJi2gjiFo+aCUeS6XMSrytxQjjZ87Ezn04aFlkB36W/nJcFJYD+Br+2E+JJvBR54+ivZS02nqwyY5ks7m+Sn/zIKIBgfqLYYn7VFld206BBFdyaiJi7hYHB9pgJ8sVA9w6te1hgLvThbxi6Rlzp1WKybZBfty2RxObNn52SWRBnJaI25SZzFRdneSluYJl7svJJ259Jwmm8r6tlBOJukwaUxIJXN0q+I6Q3mkKUinyHSPXXhdQ/836Uu8SiLPVup3jFZES1nXnPM8V1x6NAcIdzFr1CbEOnL7Hq50JpjDDqXOASSrPECEVZt+ihFdLc8PmlZ46o66QFDN2I7mSsA/k+OyubYTadeyIJs5xc5fQ73VZmPyuXnLvZscT+LlCHNwywDPWIk8mmGpAMxakoAxOFr6ItxKfSnGiAeOWgkA,iv:kOQWHi7nmIAaKxQpHKnlVPq62lJrgGIDBVCU3kc4ZUw=,tag:AbWpMXNvA9CsmUb9bnR2nA==,type:str]
+    thrift-server.conf: ENC[AES256_GCM,data:es1qnOE/V8kMD6ndMOxoe3Xb7S6CJc/WknegVZZkY69SyI2hSlWgazW8CzkppEj6btvlyr98/5OfED5YZW8SFDY/oUFXTClslRVp1Hk0Og96d7IDAnAZFlZI0PT/2LViiNlU8zXy7dQLDYysPRnLNlaNx+gJ4txuJSNFN2PitSna21tnNlhDRZmPUG5tAU8x3BpfRwlqQHMvatp0JbZI66xnH9za530+AmROYvHr9EP7fziyTntmKf2IxlOGElJeACDf50hzqKZYladbOdd66tsu9/H0K1KX830yMJ08i+onN8s2fTag34xa4SxWSXk9jXqoQCINTtuIrY1T/1gzmiRVneJhe4+VUitNBaLKmNbqYa4naDKZ1rOljjp98kImALXvLjT7jivZHkLXxqxgaPC1bHFPvyINn/dhKNuwBPv6lBiaJ5u8loAki7qxfC+7QM+aipXbnpGqssiZUl8ND140VX6BDyZnzLqNQ/8ZIAyhmhKc1vjFynTisKNs6bijWLVEI58bSp1izAYxEp3Cm7TazrVpVU3oHgHq+d4hGG/G5aCR6iZsXknoqtwMVNH+qoNg4EdAHpv9gA/YUGpEH0THhkcVWH6/nJfHDZFZ2H0Jcy1FT8ITEwrj9iIn1rx58XFEvMRtXYv0Zo0sAagYsqJdmNzeNBzvYC0L5ykdaWkDJI4H25Z74FgD1cUknY7KErDvYvJ9L+YgZ0m5jJ/Sjo/5ax56BHuWp169gUiiGIg8PqD064NMMXm+KpZKspshZlBVgKvNiviOeMGjlIXvYs+5U/5yH91Jw/MRmRqjLEWij0cszhN6QQXhrVsrTU6+EirTvL7BVBeNOlJJeja0s2a1bRIdDK6//uiH9MCWJMwKz9OKhcYfQn5v07ja2knkzl8pjsAM7agN0XJinDGIjMtunhW9V261jAkB/c4s8gHpQuEWUPl2ddWuADtcwYZG/Mkpk+iVS91cZOllHpApH/c+aO0To8N8ETDLV45fU0mKVXDAG8IXMsQJQMcvU9QtAieUOyjDMR6eReLpRIByzB9RIpIcKMTL0JsgNZVJRu3QmEmWZC3h4g4XtzT+OmvEXooipNetv0vOcChiJcfDtnATvVFKatPtF16CebE6EGCMOdnssj4KFOo2/OqHVqMKibcoIX3+9T3QWywDHHbJ/ul9VKzg8CKe7aWxdDmrZcxk+74CX2/MerUXUhemI3EFmXWoxwl781nzKCaE4J0fbqnoAy4TzpaWTQ==,iv:TTIAJy6p2AmHx4AL9gahUNnEcJ3F4e+B6mHO9cu1eXg=,tag:l1wO/vP4wtMbg+//SJ3jUQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2020-12-17T15:02:52Z'
-    mac: ENC[AES256_GCM,data:k+Pz0AO/hFrbUrgnZh7GPwjAftJ0fKB/ZG49DrcnM6ZizzewXj1WHX0djXlDAr8QEycLpPnGge2PeRKjQPXnzUgydGxOQq/nJd1oTTBP/xxlrSwnCqONuj4G6ZWpiL3hL7aOXzakaJjNOnw+5nRHNMQ+jhlAYNgQALFbYNpg0us=,iv:/XXltknKTJidfeJ3RSAnRWxvfuqTnV1j1PRoDOsWPuw=,tag:YYuFOH5fy0mHYerbBl2Sww==,type:str]
+    lastmodified: '2020-12-22T13:31:25Z'
+    mac: ENC[AES256_GCM,data:jHvdRUzhRRLsBQ5oG5nlpKO6X7IDLtTlgfeDReQ1z07/vGXXeZ1lBv25dUoYAfJac+PTWIh+TqlAt04PDsl8ylggG711gYboFweba3gxHJSLatBBPA8NWfu2u0imu4IiEVwQfAqCN+KhW8VLQYZVVSKvrHI4AUZsMoSfjbROQXQ=,iv:NLxji3bNh88BfVI9ZHxGvnvufEcJ7KgHxkTcc4ntOxU=,tag:V3FpS/ahb5ONnehtl3N48g==,type:str]
     pgp:
-    -   created_at: '2020-12-17T15:02:51Z'
+    -   created_at: '2020-12-22T13:31:24Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQEMA/irrHa183bxAQf7BTE4kQIyVU/3PyQnTxj4KCwpKnebJwu3d8UadxncmdgZ
-            KyKtoQHIxnYxmn+YxPHE7gGVD1YaM/Dn7+Rb+keoVpBJGgjrcAgbKK5ECtgp2XzF
-            fcJMaKDRcl5cAzI1QI5CrmoPwkKwKs0cDmbb2czYURpXNcwJzAiJt4xb/BmTL+6X
-            mS3pXPUE4X9z6zZ7P2koKrbUZN/zumDdSFF7JtLaVPEJmOd8pr0mTTrJ+qqfn6b1
-            tQyoWannoiQmZor0T7HQNWyrmR+IaIGr5hvQlQWp+uchPeyS+8CruaCVyBKkicbu
-            kdrRTegp8+t1wW4yTCpuBC3ODeqA4E01mN3ZDHrCDtJeAdRiqnDHFbaMtCEhQbHP
-            j9+uItaVfieRSabliduYax6F0rPkjcqqF4kI0PutKik8+w8b9CI9TRr/7+Nk0foU
-            i9E72dMzwqlz0iUCJ2iTUXw2U7oh248vMpsLK0nxsA==
-            =i2KK
+            hQEMA/irrHa183bxAQf/XmO/DL2FGWSrOgKoKKKA5pzZhBhVhhhSWey4hRyXYUB5
+            voayYtv1uvEtBmgI1+0jv4iHdJZCS0U8RcAx3ybD/Rql8XfeAurZspQ9QzvZBQyl
+            8JDauE/W9GmwURiGoeIv12Vy9uqWOvAPvOtQx0U4RX2S9dC8gu+UBaoEsD68yQ7L
+            +UvmVTQO2CM2/1KwFwiJPjot4+pzCSfYLzWVYbf7sZLRCGY3VmD38nRXDNsBzyk2
+            Bw9Vl7vzzfDiE/mM/qefYQfZJgtT9dpFAY6djHgEJjCgOI8W2UdeNVEO35kTotXI
+            TVPil7M/nEiZVxWTLzFeDJM3ryJS4FJ8jzu6JISOqtJeAb4TrSR9qNVLrX7AfhYh
+            az+PW3EuvfTNW2iMW4Dk/1pyaJvvcApIzBQ0XZuh95ahddvy+cFR5vv6DDUCBUsX
+            YVfmQpbi2PavqmW/B9fk185+q7wZRcMb5W/1G4sRFA==
+            =mLho
             -----END PGP MESSAGE-----
         fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
     encrypted_regex: ^(data|stringData|tls)$


### PR DESCRIPTION
The thriftserver instances were unable to reach the hostname that we
previously used. This change modifies the thriftserver instances to use
the external hostname and nodeport combination to reach our main spark
cluster.