### PR TITLE
Replace Node Selector for DH-STAGE-ARGO app

### DIFF
--- a/argo/overlays/dh-stage-argo/deployments/argo-server_patch.yaml
+++ b/argo/overlays/dh-stage-argo/deployments/argo-server_patch.yaml
@@ -1,0 +1,11 @@
+---
+$patch: replace
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argo-server
+spec:
+  template:
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux

--- a/argo/overlays/dh-stage-argo/deployments/workflow-controller_patch.yaml
+++ b/argo/overlays/dh-stage-argo/deployments/workflow-controller_patch.yaml
@@ -1,0 +1,11 @@
+---
+$patch: replace
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: workflow-controller
+spec:
+  template:
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux

--- a/argo/overlays/dh-stage-argo/kustomization.yaml
+++ b/argo/overlays/dh-stage-argo/kustomization.yaml
@@ -11,3 +11,7 @@ commonLabels:
 resources:
   - ../../base
   - ./membership.yaml
+
+patchesStrategicMerge:
+  - deployments/argo-server_patch.yaml
+  - deployments/workflow-controller_patch.yaml


### PR DESCRIPTION
The upstream manifests at
https://github.com/argoproj/argo/blob/master/manifests/base/workflow-controller/workflow-controller-deployment.yaml#L52
specify a nodeSelector that is not available on our nodes. This patch
will ensure that the application can still be deployed

Signed-off-by: Anish Asthana <anishasthana1@gmail.com>