### PR TITLE
Add NodeSelector patches for Prod Data Hub

### DIFF
--- a/argo/overlays/dh-prod-argo/deployments/argo-server_patch.yaml
+++ b/argo/overlays/dh-prod-argo/deployments/argo-server_patch.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argo-server
+spec:
+  template:
+    spec:
+      nodeSelector:
+        $patch: replace
+        beta.kubernetes.io/os: linux

--- a/argo/overlays/dh-prod-argo/deployments/workflow-controller_patch.yaml
+++ b/argo/overlays/dh-prod-argo/deployments/workflow-controller_patch.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: workflow-controller
+spec:
+  template:
+    spec:
+      nodeSelector:
+        $patch: replace
+        beta.kubernetes.io/os: linux

--- a/argo/overlays/dh-prod-argo/kustomization.yaml
+++ b/argo/overlays/dh-prod-argo/kustomization.yaml
@@ -11,3 +11,7 @@ commonLabels:
 resources:
   - ../../base
   - ./membership.yaml
+
+patchesStrategicMerge:
+  - deployments/argo-server_patch.yaml
+  - deployments/workflow-controller_patch.yaml


### PR DESCRIPTION
This will use the same patches we have tested with stage for prod manifests.

As a note, prod is not yet managed by ArgoCD, so this won't actually affect anything

Signed-off-by: Anish Asthana <anishasthana1@gmail.com>