### PR TITLE
Add the Kafka exporter

### DIFF
--- a/kafka/templates/kafka-cluster.yaml
+++ b/kafka/templates/kafka-cluster.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ $.Values.kafka_cluster_name | quote }}
   namespace: {{ $.Values.namespace | quote }}
 spec:
+  kafkaExporter: {}
   kafka:
     version: {{ $.Values.kafka_version | quote }}
     readinessProbe:


### PR DESCRIPTION
This will configure Strimzi to deploy the Kafka Exporter service
alongside the kafka cluster, allowing us to do away with our custom
kafka consumer lag exporter.