### PR TITLE
Tune the thresholds for the Thriftserver liveness probe

### DIFF
--- a/data-catalog/base/thriftserver/thriftserver-dc.yaml
+++ b/data-catalog/base/thriftserver/thriftserver-dc.yaml
@@ -63,12 +63,12 @@ spec:
               cpu: "4"
               memory: 1Gi
           livenessProbe:
-            failureThreshold: 4
+            failureThreshold: 2
             httpGet:
               path: /jobs/
               port: 4040
               scheme: HTTP
-            periodSeconds: 30
+            periodSeconds: 10
             initialDelaySeconds: 300
             successThreshold: 1
             timeoutSeconds: 5


### PR DESCRIPTION
We regularly have to restart the Thriftserver. When we do so, we can
often see in the pod events that the liveness probe has been failing,
but evidently not frequently enough for OpenShift to trigger a container
restart. This change should make OpenShift more sensitive to probe
failures.