### PR TITLE
Remove capabilities dict from data catalog deployment configs

### DIFF
--- a/data-catalog/base/hue/hue-mysql-dc.yaml
+++ b/data-catalog/base/hue/hue-mysql-dc.yaml
@@ -88,10 +88,6 @@ spec:
           terminationMessagePath: "/dev/termination-log"
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
-          capabilities: {}
-          securityContext:
-            capabilities: {}
-            privileged: false
       volumes:
         - name: mysql
           persistentVolumeClaim:

--- a/data-catalog/base/thriftserver/postgres-dc.yaml
+++ b/data-catalog/base/thriftserver/postgres-dc.yaml
@@ -89,10 +89,6 @@ spec:
               mountPath: "/var/lib/pgsql/data"
           terminationMessagePath: "/dev/termination-log"
           imagePullPolicy: IfNotPresent
-          capabilities: {}
-          securityContext:
-            capabilities: {}
-            privileged: false
       volumes:
         - name: "postgresql-data"
           persistentVolumeClaim:


### PR DESCRIPTION
These are showing up as out of sync in argocd. These values are
defaults, so there is no need to have them in git. I'm hoping that
removing them will help with the diff.