### PR TITLE
feat: Add aicoe-ccx to aiops-prod-argo project

### DIFF
--- a/argo/overlays/aiops-prod-argo/membership.yaml
+++ b/argo/overlays/aiops-prod-argo/membership.yaml
@@ -29,6 +29,18 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  name: project-editors
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+subjects:
+  - kind: Group
+    name: aicoe-ccx
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
   name: project-argo-users
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -43,6 +55,8 @@ subjects:
     name: aicoe-aiops-devops
   - kind: Group
     name: aicoe-aiops
+  - kind: Group
+    name: aicoe-ccx
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
@mbacovsky requested better access to this namespace (and Argo) for `aicoe-ccx` folks - via cli and console.

- Added 2 new users to that rover group (may need up to 24h to propagate) outside of this PR
- Granting the group access to the namespace via `edit` cluster role and `argo-user` role