### PR TITLE
Update spark config for ccx thriftserver

### DIFF
--- a/data-catalog/overlays/prod-ccx/thriftserver/thriftserver-server-conf-secret.enc.yaml
+++ b/data-catalog/overlays/prod-ccx/thriftserver/thriftserver-server-conf-secret.enc.yaml
@@ -7,28 +7,28 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 stringData:
-    thrift-server.conf: ENC[AES256_GCM,data:zWXETsSDHtleEzmT3rb6XaS1203/a5JYK/cw2Uwv23oeKTw8bZnRoKprFA6TQRJBXG6ej4nzDnZYjC9sGcAct4nW8U1b52O670nARUSL8168d/qgQEVxWbL8x6btoZXHERd6qKs2CSthyHiUfh2RpMi4IiOimeu7n036MEeGvXULrfXyS9BAcJ9XTCVvLi0wbyzxr0fYdv41vZCDZvrh3WR8JLa+15z9qVbOVkI3J5arqGOM6h5q+//4sdAhImA3PpvJL1lofaYY8vO3QLzsJEM/3Wk8L4eSlNUcMocx+ygaqlbdi6XZjaVZTVGJw4Tvwl/5h+TK295VWS7nHJfRSQ6DcSKPkntxAp7V3wQbtOctS5Flq3X+qRDi4cDLvPS3VABAqk8aSTLu4IWBhZqYpCzqDQaGblQs77h6iniCAoPTpqasJtsyw1k+hsobNUZy8mXJlXHEqHQ9xYqDZDFoaqVMFjg75cp9sx7nqpwbq8wj4kWNGXR51c5U45UZLki3tTl0YSYT4BZD53DTCchNPOMIzpM9+04207uC7OkJuONRSQa6O0koGCLssl09Jq8Yf0kcibmMUawMsN4QXxG4Oi4Ajr1bczscRfgy1NaPJnQGywMqZPO53zf9CwpEj7eEi6UxZFwbrb2opid5RACiKcz7ar9dL10vI7P4gO54QVEszI6i59xj4erWadPYat5vSak06+EsmevVOCabgR/eDsdul+KBZoU7X2qKf/w+TrzV989XTmxjFR/mOUdC7c3vFnQzgtmiSekZ4CDs982JoBoG+isXLmAZI9TZOJyqkDoBquvtoDKEQ/qZ5qHIC4VNiEpALiW5NmxGl0b6uWyHEzTQXCvyNKgPiGg7C1cJJgngLmDi7AN7k7dAbcrjred/AKLOcFQhnK3mgKUtlVdc79JCr64Io1veYEMEqVkO5SDDoc7Mh8261MraYlcC7i0B7jZNpFn6RpH4tR9yagP+8vVNxHO5w+WgzMmsdqhjKeq3pwju62Qa9oO8Zj6q3ib6xR9s2edqSUqsLbogiL7xMlDvYdXqIED1RMbsPMAvCJStbCRUfUS6hTfyE2nOaxl/wuQN1sKBmxK/5Hilmv2xSGywR3nU4BluyZJZy3dLOD0S0wnIauSevF23qVbX5FQAgvZvwVnus3DpCFBr/94SX365jKm3w9PukobEovxVV0GHAOQaDqWDHcG4YWBbV/NLeQB7A20euEanImQYmf4oP5KlY2qxewiTLM2y9w9ydeksjwrBnyJ3Yck90ym54I4mvTitgYU6KXM01F4oWLhzDroXrylVJoJG0jmzk7Mf1009az0IbUgXBLc9o2mF01dF3xlZIrw0ozRi2sTpMDholw8CkLfD9DhFkKtQ+pCX3Nql3ZsE8JfReBVpIqOxKvc7gUBTKDafMz9jtFHksYpNSkmC5A0vlVllCvt27Klg17PI6SLtuY67svdd6fej2fj4X5zgXkX/n9aW7K3STrxJUYeoIxbHrcPfzNOHGBlW9klDl+4P7jdDxK4y6wZujaIOE7kzbWjR8ib9Wx58rEmdQdHN78vE33s/EoMJgfvFTGb5fF0JKODWhzmJl0N1sJDroyi0v+zkf4nwm8H3XKxsDtsmA1WvNkN4OxOk9iwDhCgdXEFQpBJj8ceOuqwcfFO35pIQMYaePYq0aV+P7O0Wm31FIPv8,iv:gfs88KRboJ6n1PYkvj0wQ8neNR0qV2vEDmZjwCpomFc=,tag:4fbxzLZyoqMQlVuQDjSZXA==,type:str]
+    thrift-server.conf: ENC[AES256_GCM,data:QWcCOe1qHxi2fa7B1otRgwzJ+69WDTUJY6LhPHeKiLnKjD8QxfRdjvJcoOuwrSLx/7kgcOB36nRAfp0e5XRYKByCMUI1baCqPtAS+l0OCTblTSfQWB5E/WqeW5bOQc93izu7cGQORZb02TJFkpQ6OVbwhLdbZqCMJoa8c6qPb8lKzSsd2F29kq2E7s9yGnmVTRW4spozPd1/XLaqqyE6BCh+qnzub+WHo6UkRfCbR5Pjp/Rsc1CbzBVCwluMwPAtuZpVkiBxib/0ECMF32VcU2qMwrEcaQ4sCE5PddGhYlVOPyimkKeIvTpqTLgeWZW4dpvj9v0gWHcd+K72VYwAu8epkBwrHNZoDDPqwLM86pdFNTLIgo9/KWCtwugA+3bpE9ogEZw9eIeAC2E/M+Hnr2zwVV14DLzwpPqzjMEf9q/gNmlRyEy5gq619RhdnyslFpdAKdQg5tmljVAGO3IV4k5+ntekF3pnHULp0I4B6IoF+DLyVTvpziN7C7/GKM7nhWxrujFJ4z+zXGw8XrVXjwkP+3Qxt7avm2cJfMpm9QX+Q014u9s+DoguPOWtcpwnYa2gWzgfTLurR+aq+wkJ6Zu+HXhi3bJYGFKVyBS+OT4NDeXzAoIsTO11PE6olSAvKIAh2g2NQsvLfSMvpU7ZR3MRcDXo+tStMdFmuJ7AhPMpGBi/cX1qxCkiWTLpZoMmL0a/oz7wgni79xWv3pXv5yTAZ1qdgqfqdxAxKrJTJfNwbt0uIuMI8CSVv3oW9zymSFklkMCBXf9ayTm3lK/k5dk6Vn4dxvQDDmayttbrAWIDogXdsjJXxuFd3UqryXEQrM4oJgkp0CEbOZpQsFk1JPR0A20lDL4FpEIVxBe3kXsyXtVwczVSnjNCNUEFHT/b6vZ3PT1pykOBHGkXRcUi2vsiXkF5fgs2nlo0uCKIO96PdFUxgmuftOmSmYQZj96REpBomqDwBFFEr6GbVs7PWHIfxqgqQKKe+ZxHn71668bv/32XyxkblvvrplcqvJF9OPemyu4yon4azmD0wrISe6DaTGr4BI+APWAMKVqZH2l73R5+e6bZQN84C0JZz/uHRnecHdE50v+KefOllc28Q4yHMRUXYGeTzQCQx0uOdUhQTJ+s/V7Uk32LwsQpH+ZAb0ft68dx8ssDQq0Q3dDA8oQnHaRUWOYxyrmw7DmI6pmVBXjJYOmSbgYMzD/0RMgxBPh4nkkQi65in21Gxxbb88YRxIdBZOKgagrilfxQacU1bdFMYm7j7fAoSoJ1iwkaOZmXq6W9ho1ycT48R8l1v4n8YYmA9qH5GhAsIrvWZu+vphbBVI9e0cGncPj6uF3kCrKzuHf/jBUMZgJ6p+V8numCTy5qXFYGDsQP8C9yarjKoXKIWHPxtYrJHZXcG+EkOaw/nad35F4Cipi0VJ+tgsNxpLNU8PKUQhfqaSonTMoYXw//Xb9mqKRW6ou76GtFcZePgrapIpRfRqDNONG3p/vhrD57JVTlyGotTt69tHXxcMrdrAwqvBwK68h9u7lw0PxUdFgV13iS7gRPLjdQEUkuVzfr2qgRdcrbuMO8bymo7S/TFwy2gmMd6y/tuKi+hTu19kDln3zP8ZzD/mJ//0OwxHQuPdY7YJvqT9m9RX1PpIvuVBAW8jmS70eu0kH5A/7KOUQFOMBXK6E9P7tzyfYrJ4ipaTBu35GyxzvxCb6ObL/mnLobilgxmnq/mA==,iv:T8I+XaDZMGmHWbcG3SWqDWAgh5PYl82fu9ec+u+hzSk=,tag:AvnoXINipj7B0i2U42IWtw==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-01-06T19:52:17Z'
-    mac: ENC[AES256_GCM,data:fpkimYtyqwM1OXzdTnDPfXKG/aXdNmZeLAbkBbfKl4nUIfEg3EXJL7LeVGbHQ1kUpf15At280sDh9mbwGLvlLajqX98AUFhmXlsVboY10fuwmW9yI4MDlnj3QOzbbd4okgzzmhkDQ1qIoBfQzzhrBvEvOnL9i7EfCcKUNn7Jsnw=,iv:MvprxbdxOKaBcCVhekcIwojhBaIOMoHPUYU068uLK2M=,tag:18keO+QwWFQwJakQfzddHw==,type:str]
+    lastmodified: '2021-03-29T13:27:38Z'
+    mac: ENC[AES256_GCM,data:eb1wBXD3K50J4RindRxil539XAuceB9mH+B2rKvpg/KAzm+pdc+XgLLZOjM5xu+hO84JnUlgIq+I7hYExEL/QA5u2pefbrf0Lu0S5a4FWFpiqSV3AOBLJGb9qWn8jUl+M56Ptc029BNuIUfhgFkhBSc7QcQz7ohqFAIMjHbT7uU=,iv:+TyOePehZkfEfLIXFJSnMo5WKK+iXt0iaOrvuKu8RVQ=,tag:YqU9t2tn1cMFzq/IkYRK5A==,type:str]
     pgp:
-    -   created_at: '2021-01-06T19:52:16Z'
+    -   created_at: '2021-03-29T13:27:37Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQEMA/irrHa183bxAQf/VttThxN6k9/JLGaKQeTdSoQOhO2RhZ+gYxYYisTv7PAQ
-            q0B8LXF3EhAbBRnuB8i3/JeMpuJdvIbPnn1up+pHC4fwTdCkdVXZ1hUIfDZdFzXs
-            sT1VyAfYjjRRfwBN9U0uhgxNZj4oIw9l8jQJ8Wm64CyJiwcQ1WDUHoP7ylSqCH6c
-            fDgzFUj/0haDLTiiklemed0LaHGsPsqOB8zkKLarxsLcPntxJYzIp1MUz2LaRgGZ
-            VJcjv4iaU5gvxHS3Jr22ksJgrHZfhQM2GMU6APBwuWz14HMxqU/d1HwTBIiyF4kd
-            Hu9JOae+cAf7U2p3zP5rwb6DNz6UjUtmL5tD9q5SBtJeAXUILyOKsUWGDHXPT93L
-            80iDVs+sbkLSgbSns3nxWsB9MsWnvJYD7dTFyrrbYhGLiNPNdqwqhMBizJqCr8+P
-            Pv8aCAqObepNKdqE0FifNV6xAxnij76BcSdh7onmPQ==
-            =g04Q
+            hQEMA/irrHa183bxAQgAkSNmgAcUO28uCFm98jg7j1TGjfksnSYXXpgLDYdNcjKl
+            KtNOjI5ASTyqVi4nIuPOqlxOgu9+hsFZM2+HTXuJF3/AhUbMmu76pdIkO131dtW+
+            gCBq5RPbyN/at7S0Lv/v/15PWEdjGvw3xK46qJsZaYJH0NH1jfWzdE9EMtlJWLIq
+            FqN0hV8FhNdaXQoALIvEByRwVvNW8pEYVaM+jKJA6rmKJxO/ZfPsgXfDjYE2fWwq
+            GxFVKyloQbG+VzE61yqt4blcT3yBJbyhF1cr/yixbEq7omQ/pT1GxYfbhR5Uzy+n
+            bj+Y2kId8pic15a7CwM5WJNBDrTIWRGx49Y7+gqJJ9JeAfRs1oXth4uaDfdviP9U
+            p30jUlcr+YSrhcfYp8hbC6ROh6zYaaV/kJz+fqph1A6v8LJO73dJXGkHyk2TYnGk
+            16LHPb3EniRvfj5CSzP4mDXYuyOQP0lE3WY1+FjAGA==
+            =8fDR
             -----END PGP MESSAGE-----
         fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
     encrypted_regex: ^(data|stringData|tls)$


### PR DESCRIPTION
This updates the configuration for the CCX thriftserver so that jobs
submitted to spark know how to route back to the thriftserver
(previously the spark jobs were trying to use the namespace-scoped
thriftserver service which can't be routed to from the
dh-prod-analytics-factory namespace