### PR TITLE
Remove qe-ds membership for argo events

### DIFF
--- a/argo-events/overlays/dh-prod-argo/membership.yaml
+++ b/argo-events/overlays/dh-prod-argo/membership.yaml
@@ -17,5 +17,3 @@ subjects:
     name: esammons
   - kind: User
     name: jeking
-  - kind: Group
-    name: qe-ds


### PR DESCRIPTION
The sync for this was breaking and it turns out it's not necessary