### PR TITLE
Enable SQL templating in Superset

### DIFF
--- a/superset/templates/odh_cr.yaml
+++ b/superset/templates/odh_cr.yaml
@@ -103,4 +103,8 @@ spec:
 
       AUTH_ROLE_ADMIN = 'Admin'
 
-      PUBLIC_ROLE_LIKE = 'Gamma'"
+      PUBLIC_ROLE_LIKE = 'Gamma'
+      
+      FEATURE_FLAGS = {
+        'ENABLE_TEMPLATE_PROCESSING': True,
+      }"


### PR DESCRIPTION
With the Superset 1.1.0 upgrade, SQL Templating was disabled by default. This change will enable again the feature.