### PR TITLE
Remove the storage class for stage trino PVC

### DIFF
--- a/trino/overlays/stage/trino-db-pvc.yaml
+++ b/trino/overlays/stage/trino-db-pvc.yaml
@@ -4,8 +4,6 @@ metadata:
   name: trino-db-volume
   labels:
     app: trino
-  annotations:
-    volume.beta.kubernetes.io/storage-class: "nfs"
 spec:
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
We're no longer using a storage class on this cluster