### PR TITLE
Fix kustomize build of trino overlays

### DIFF
--- a/trino/base/kustomization.yaml
+++ b/trino/base/kustomization.yaml
@@ -26,6 +26,9 @@ commonLabels:
   opendatahub.io/component: "true"
   component.opendatahub.io/name: "trino"
 
+generators:
+- ./secret-generator.yaml
+
 generatorOptions:
   disableNameSuffixHash: true
 

--- a/trino/base/secret-generator.yaml
+++ b/trino/base/secret-generator.yaml
@@ -3,4 +3,4 @@ kind: ksops
 metadata:
   name: secret-generator
 files:
-  - aws-secret.enc.yaml
+  - root-ca-secret.enc.yaml

--- a/trino/overlays/prod/secret-generator.yaml
+++ b/trino/overlays/prod/secret-generator.yaml
@@ -5,4 +5,3 @@ metadata:
 files:
   - aws-secret.enc.yaml
   - trino-db-secret.enc.yaml
-  - ../../base/root-ca-secret.enc.yaml


### PR DESCRIPTION
Having a secret generator pointed to a file that's not in the current
overlay directory isn't valid Kustomize. This change creates a secret
generator in base for the Trino Red Hat ca cert then removes pointers to
this cert definition from the stage and prod overlays.