### PR TITLE
Add file authenticator for service account creation

### DIFF
--- a/trino/base/trino-config-secret.yaml
+++ b/trino/base/trino-config-secret.yaml
@@ -12,6 +12,7 @@ stringData:
     discovery.uri=http://localhost:8080
     http-server.authentication.type=PASSWORD
     http-server.process-forwarded=true
+    password-authenticator.config-files=/etc/trino/ldap-authenticator.properties,/etc/trino/file-authenticator.properties
   config-worker.properties: |-
     coordinator=false
     http-server.http.port=8080
@@ -35,16 +36,21 @@ stringData:
   node.properties: |-
     node.environment=$(trino_environment)
     node.data-dir=/tmp/data/trino
-  password-authenticator.properties: |-
+  ldap-authenticator.properties: |-
     password-authenticator.name=ldap
     ldap.url=ldaps://ldap.corp.redhat.com
     ldap.ssl-trust-certificate=/etc/trino/certs/RH-IT-Root-CA.crt
     ldap.user-bind-pattern=uid=${USER},ou=Users,dc=redhat,dc=com
+  file-authenticator.properties: |-
+    password-authenticator.name=file
+    file.password-file=/etc/trino/password.db
+  password.db: |-
+    trino-admin:$2y$10$l9G7GLksnvOSGtM7av9Ja.g3oIO4HgYi3yFhKQz0YFLMy/itp4qLq
   group-provider.properties: |-
     group-provider.name=file
     file.group-file=/etc/trino/group-mapping.properties
   group-mapping.properties: |-
-    data-hub-admins:aasthana,acorvin,gfrasca,lferrnan,rmartine,mshah
+    data-hub-admins:aasthana,acorvin,gfrasca,lferrnan,mshah,rmartine,trino-admin
     ccx:afalossi,mbacovsk,mklika,ometelka,tdosek,tsedlace
     grokket:jmarlow,lmasse,mguan
     product-marketing:rking,tibrahim

--- a/trino/base/trino-coordinator-dc.yaml
+++ b/trino/base/trino-coordinator-dc.yaml
@@ -37,8 +37,12 @@ spec:
                 path: log.properties
               - key: node.properties
                 path: node.properties
-              - key: password-authenticator.properties
-                path: password-authenticator.properties
+              - key: ldap-authenticator.properties
+                path: ldap-authenticator.properties
+              - key: file-authenticator.properties
+                path: file-authenticator.properties
+              - key: password.db
+                path: password.db
               - key: access-control.properties
                 path: access-control.properties
               - key: rules.json


### PR DESCRIPTION
This will help create automated tasks for Trino, like creating table definitions or update partition metadata