### PR TITLE
Add new groups to access Trino environment

### DIFF
--- a/trino/base/trino-config-secret.yaml
+++ b/trino/base/trino-config-secret.yaml
@@ -55,6 +55,12 @@ stringData:
     grokket:jmarlow,lmasse,mguan
     product-marketing:rking,tibrahim
     openshift-community-enablement:jfiala
+    openshift:ccoleman
+    acm-observability:jbanerje
+    openshift-qe:esammons
+    ansible-engineering:lsmola
+    usir:sperkins
+    openshift-analytics:rzalavad
   access-control.properties: |- 
     access-control.name=file
     security.config-file=/etc/trino/rules.json
@@ -79,7 +85,7 @@ stringData:
           "owner": true
         },
         {
-          "group": "ccx|grokket|product-marketing|openshift-community-enablement",
+          "group": "ccx|grokket|product-marketing|openshift|openshift-community-enablement|acm-observability|openshift-qe|ansible-engineering|usir|openshift-analytics",
           "schema": "telemetry",
           "owner": true
         },
@@ -93,7 +99,7 @@ stringData:
           "privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP", "GRANT_SELECT"]
         },
         {
-          "group": "ccx|grokket|product-marketing|openshift-community-enablement",
+          "group": "ccx|grokket|product-marketing|openshift|openshift-community-enablement|acm-observability|openshift-qe|ansible-engineering|usir|openshift-analytics",
           "schema": "telemetry",
           "privileges": ["SELECT"]
         },


### PR DESCRIPTION
New groups created:

* openshift, with ccoleman as user
* acm-observability, with jbanerje
* openshift-qe, with esammons
* ansible-engineering, with lsmola
* usir, with sperkins
* openshift-analytics, with rzalavad