### PR TITLE
Allow all groups to access system schema and increase prod Trino memory limits

### DIFF
--- a/trino/base/trino-config-secret.yaml
+++ b/trino/base/trino-config-secret.yaml
@@ -86,7 +86,7 @@ stringData:
         },
         {
           "group": "ccx|grokket|product-marketing|openshift|openshift-community-enablement|acm-observability|openshift-qe|ansible-engineering|usir|openshift-analytics",
-          "schema": "telemetry",
+          "schema": "telemetry|system",
           "owner": true
         },
         {

--- a/trino/overlays/prod/kustomization.yaml
+++ b/trino/overlays/prod/kustomization.yaml
@@ -58,7 +58,7 @@ patchesJson6902:
   - patch: |
       - op: replace
         path: /data/trino_memory_limit
-        value: '12Gi'
+        value: '16Gi'
     target:
       kind: ConfigMap
       name: trino-config


### PR DESCRIPTION
These two changes are requested by users to have proper access to Trino from DBeaver and run queries to retrieve more data.