### PR TITLE
Fixed repo reference in argo workflow

### DIFF
--- a/argo/README.md
+++ b/argo/README.md
@@ -6,7 +6,7 @@ Kustomize templates for deploying Argo into Argo CD managed namespaces.
 
 ### Base
 
-The base folder points to a remote kustomize base for [Argo](https://github.com/argoproj/argo/tree/master/manifests). It uses a namespaced variant of the manifests.
+The base folder points to a remote kustomize base for [Argo](https://github.com/argoproj/argo-workflows/tree/master/manifests). It uses a namespaced variant of the manifests.
 
 Additionally all generic Roles are defined here.
 

--- a/argo/base/kustomization.yaml
+++ b/argo/base/kustomization.yaml
@@ -7,8 +7,8 @@ resources:
   - ./default-sa-rolebinding.yaml
   - ./argo-server-route.yaml
   - ./workflow-controller-metrics-route.yaml
-  - github.com/argoproj/argo/manifests/namespace-install?ref=v2.12.5
-  - https://raw.githubusercontent.com/argoproj/argo/v2.12.5/manifests/cluster-install/workflow-controller-rbac/workflow-aggregate-roles.yaml
+  - github.com/argoproj/argo-workflows/manifests/namespace-install?ref=v2.12.5
+  - https://raw.githubusercontent.com/argoproj/argo-workflows/v2.12.5/manifests/cluster-install/workflow-controller-rbac/workflow-aggregate-roles.yaml
 
 images:
   - name: argoproj/argocli


### PR DESCRIPTION
It seems that argo has renamed it's workflow project from `github.com/argoproj/argo` to `github.com/argoproj/argo-workflows` as you can check [here](https://github.com/argoproj/argo-workflows/releases/tag/v2.12.5).

Kustomize will break with the old reference.