### PR TITLE
Reduce retention for busiest topics

### DIFF
--- a/kafka/secrets.enc.yaml
+++ b/kafka/secrets.enc.yaml
@@ -8,12 +8,13 @@ kafka_topics:
 -   topicName: ENC[AES256_GCM,data:kj9Zv0RQ5Q==,iv:yAGH5pllYZkLxnu2sJW55TSLpk9DZ9otA13jXlxbGiI=,tag:AJKLlnXdc+heib5Pe2sRtA==,type:str]
 -   topicName: ENC[AES256_GCM,data:/SaT99qM0EveQRWXW4fj9Ps=,iv:/be9ON6TMTJsaWTiyPxO4ejLIM85sr1I9jsEzdcFBUw=,tag:i7ouPR4n3T27gNHV5/MzjQ==,type:str]
 -   topicName: ENC[AES256_GCM,data:LFY21fvRzXHdDjN/VMA=,iv:oRgvB+Nu9rUd5eU3CuI/pe1qQKqa1AGy6/n1KkqAqic=,tag:1HzX4JYhjet2OZnWh4+gGA==,type:str]
+    config:
+        retention.ms: ENC[AES256_GCM,data:URzFquuwhCM=,iv:cWPX47BzElTe0yR6uvC87Cn2QCtjVRbLCs9YeWTKWfw=,tag:9gDwO9kE/49djkyemydHTA==,type:int]
 -   topicName: ENC[AES256_GCM,data:r5w49roj1Zkh4Y3ys7tG,iv:rUaWL6vBv3lBkDycasDZiflbDZ53mw0VQT6lxy3527M=,tag:u4ZtfD1RiSWVhEEoEcK1qw==,type:str]
--   config:
-        retention.bytes: ENC[AES256_GCM,data:GvHH79DCPwmLFAI=,iv:VWtZMLVbiwiM5kG0+Gl1Dd90I+6IF1ioYSmWos6H6mc=,tag:pCYos3HgWQha4lKd7ZbPlQ==,type:int]
-        retention.ms: ENC[AES256_GCM,data:T+nuREf4z7Qo,iv:rNCx1bnwj3gIyRrgh/ALYi7rJp4v4XNi8PaLONqzfKU=,tag:bgKM+2X1FPJxDz1fX0Euzg==,type:int]
+-   topicName: ENC[AES256_GCM,data:qKBVpQPGFJJGwoffbIU=,iv:D1DKpkn3Zs4srpgps7827ljxgYSX+kzfTeMRhcYXaVo=,tag:muwj0T8QyX/gL8mo77fYCw==,type:str]
     partitions: ENC[AES256_GCM,data:hAA=,iv:p6nuSZRaCUBLWhlsZODSh+z3Q+kVt7pQTyysd7m6ivg=,tag:8Ub6Nn4SLCKG8UbxCnxYfw==,type:int]
-    topicName: ENC[AES256_GCM,data:qKBVpQPGFJJGwoffbIU=,iv:D1DKpkn3Zs4srpgps7827ljxgYSX+kzfTeMRhcYXaVo=,tag:muwj0T8QyX/gL8mo77fYCw==,type:str]
+    config:
+        retention.ms: ENC[AES256_GCM,data:2Gnc55XdxOc=,iv:eRYNJpDH81i2YFACyh6XQSm4SOF1rsobOrZZkPXe8yA=,tag:GuEJSLqQHVO9PYqDLeRFGw==,type:int]
 -   topicName: ENC[AES256_GCM,data:/kkr2J5zQxq3jsdeczzj,iv:QDlZN2H7meeiTO7Rhm6evHwefzX/BQocGCDnLLJdtng=,tag:6M1WP2W0XFcg2aor7o+V8g==,type:str]
 -   partitions: ENC[AES256_GCM,data:WqI=,iv:NvyXZQHn9YipDVLYzSxphFuwLsYmUWZRy5+LmZ5LIYU=,tag:PSi/r9MkRsAovYrilXNtKA==,type:int]
     topicName: ENC[AES256_GCM,data:CCgH57hmz4fZ63/wlevcadmcd+0R4wQgzrMqBirnqjg=,iv:O/enGs1jtH6fZqWeaIHukwmV88PogSyfJf1YhmaRhTY=,tag:+oV0mO/5cyJDel+n3D3SSg==,type:str]
@@ -212,8 +213,8 @@ sops:
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-12-07T00:28:15Z'
-    mac: ENC[AES256_GCM,data:2X3WmQO6vJeFtot5RmP9KZ+Kzl7/CzbLa23wthACaWxRLL0z4a6jQNccEaEJaXMMSzwBILeKCbdaKY3dqtafYM1EN5+x8nT+t61ld9QGLqqLwJ+ic/O0s8pozavXnclbE7VfWUZeNtfiJYIbKbjP4QvHz80FDCZXZxvfgfUHi0I=,iv:+MaVzoOAUa8U1hwasfRSRZuhVt+o7FyU3evdQEAtZE0=,tag:VI4hRxH5vQtwZFHHTarN4g==,type:str]
+    lastmodified: '2022-01-12T14:17:57Z'
+    mac: ENC[AES256_GCM,data:fUikVgeegmButajXSbWZxQ/d6xzqt+F7f5GkmK5ydZpq3jKdxm3QUk9GE4hpSjVTv0g2GPffOv7JPbUl3234Ixan65NQL+8RSVls7HWSSFMhlK0tP2qyh0I3jqyi/3C5XlHh86kIpWVvFvu6Vl9tkXWKjQrW9q3jrVmZLKYh9Wg=,iv:X0QKWNfrZwfz0V8tMFJzJZDhqeciyQQXXC3eWs1SGWI=,tag:XwcsSfguLgBeepUmT9MtoQ==,type:str]
     pgp:
     -   created_at: '2021-08-26T20:05:20Z'
         enc: |


### PR DESCRIPTION
This reduces the retention for the rsyslog and fluentd topics from 2 to
1 days which should help with our Kafka disk space alerts.